### PR TITLE
Removed leading UTF-8 BOM mark

### DIFF
--- a/rdf/dwcterms.rdf
+++ b/rdf/dwcterms.rdf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   To use the stylesheet to make the RDF more readable in a web browser, 
   uncomment one of the the following stylesheet references:

--- a/rdf/dwctermshistory.rdf
+++ b/rdf/dwctermshistory.rdf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   To use the stylesheet to make the RDF more readable in a web browser, 
   uncomment one of the the following stylesheet references:


### PR DESCRIPTION
The RDF files `rdf/dwcterms.rdf` and `rdf/dwctermshistory.rdf` are encoded in UTF-8 with a leading three-byte Byte-Order-Mapping (BOM). The presence of this BOM causes issues with certain RDF readers (particularly RDF.rb in ruby). This Pull Request removes the initial three bytes from these files so that they are encoded as simple UTF-8.

See also the discussion here: https://github.com/projecthydra-labs/rdf-vocab/issues/35