### PR TITLE
Fix #143 : Consistent capitalisation of coreId

### DIFF
--- a/text/tdwg_dwc_text.xsd
+++ b/text/tdwg_dwc_text.xsd
@@ -70,7 +70,7 @@
 		<xs:complexContent>
 			<xs:extension base="arch:fileType">
 				<xs:sequence>
-					<xs:element name="coreid" type="arch:idFieldType" minOccurs="1" maxOccurs="1"/>
+					<xs:element name="coreId" type="arch:idFieldType" minOccurs="1" maxOccurs="1"/>
 					<xs:element name="field" type="arch:fieldType" minOccurs="1"
 						maxOccurs="unbounded"/>
 				</xs:sequence>


### PR DESCRIPTION
Fixes the capitalisation of "coreId" in the XSD to match common usage and the Darwin Core Text Guide HTML text.