### PR TITLE
dcterms link to terms.tdwg.org

### DIFF
--- a/www/guides/index.html
+++ b/www/guides/index.html
@@ -138,21 +138,21 @@
                         <h2>Record-level</h2>
                         <div class="my-4">
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:type">type</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:type">dcterms:type</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:modified">modified</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:modified">dcterms:modified</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:language">language</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:language">dcterms:language</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:license">license</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:license">dcterms:license</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:rightsHolder">rightsHolder</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:rightsHolder">dcterms:rightsHolder</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:accessRights">accessRights</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:accessRights">dcterms:accessRights</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:bibliographicCitation">bibliographicCitation</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:bibliographicCitation">dcterms:bibliographicCitation</a><!-- link to term -->
                             
-                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:references">references</a><!-- link to term -->
+                            <a class="btn btn-sm btn-outline-secondary m-1" href="#dcterms:references">dcterms:references</a><!-- link to term -->
                             
                             <a class="btn btn-sm btn-outline-secondary m-1" href="#dwc:institutionID">institutionID</a><!-- link to term -->
                             
@@ -187,7 +187,7 @@
                                 <tr class="table-secondary"><th colspan="2">type<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/type">http://purl.org/dc/terms/type</a></td></tr>
                                 <tr><td class="label">Definition</td><td>The nature or genre of the resource.</td></tr>
-                                <tr><td class="label">Comments</td><td>For Darwin Core, recommended best practice is to use the name of the class that defines the root of the record. Examples: <code>StillImage</code>, <code>MovingImage</code>, <code>Sound</code>, <code>PhysicalObject</code>, <code>Event</code>, <code>Text</code>. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:type">http://terms.tdwg.org/wiki/dwc:type</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>For Darwin Core, recommended best practice is to use the name of the class that defines the root of the record. Examples: <code>StillImage</code>, <code>MovingImage</code>, <code>Sound</code>, <code>PhysicalObject</code>, <code>Event</code>, <code>Text</code>. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:type">http://terms.tdwg.org/wiki/dcterms:type</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -197,7 +197,7 @@
                                 <tr class="table-secondary"><th colspan="2">modified<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/modified">http://purl.org/dc/terms/modified</a></td></tr>
                                 <tr><td class="label">Definition</td><td>The most recent date-time on which the resource was changed.</td></tr>
-                                <tr><td class="label">Comments</td><td>For Darwin Core, recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E). Examples: <code>1963-03-08T14:07-0600</code> is 8 Mar 1963 2:07pm in the time zone six hours earlier than UTC, <code>2009-02-20T08:40Z</code> is 20 Feb 2009 8:40am UTC, <code>1809-02-12</code> is 12 Feb 1809, <code>1906-06</code> is Jun 1906, <code>1971</code> is just that year, <code>2007-03-01T13:00:00Z/2008-05-11T15:30:00Z</code> is the interval between 1 Mar 2007 1pm UTC and 11 May 2008 3:30pm UTC, <code>2007-11-13/15</code> is the interval between 13 Nov 2007 and 15 Nov 2007. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:modified">http://terms.tdwg.org/wiki/dwc:modified</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>For Darwin Core, recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E). Examples: <code>1963-03-08T14:07-0600</code> is 8 Mar 1963 2:07pm in the time zone six hours earlier than UTC, <code>2009-02-20T08:40Z</code> is 20 Feb 2009 8:40am UTC, <code>1809-02-12</code> is 12 Feb 1809, <code>1906-06</code> is Jun 1906, <code>1971</code> is just that year, <code>2007-03-01T13:00:00Z/2008-05-11T15:30:00Z</code> is the interval between 1 Mar 2007 1pm UTC and 11 May 2008 3:30pm UTC, <code>2007-11-13/15</code> is the interval between 13 Nov 2007 and 15 Nov 2007. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:modified">http://terms.tdwg.org/wiki/dcterms:modified</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -207,7 +207,7 @@
                                 <tr class="table-secondary"><th colspan="2">language<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/language">http://purl.org/dc/terms/language</a></td></tr>
                                 <tr><td class="label">Definition</td><td>A language of the resource.</td></tr>
-                                <tr><td class="label">Comments</td><td>Recommended best practice is to use a controlled vocabulary such as RFC 5646. Examples: <code>en</code> for English, <code>es</code> for Spanish. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:language">http://terms.tdwg.org/wiki/dwc:language</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>Recommended best practice is to use a controlled vocabulary such as RFC 5646. Examples: <code>en</code> for English, <code>es</code> for Spanish. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:language">http://terms.tdwg.org/wiki/dcterms:language</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -217,7 +217,7 @@
                                 <tr class="table-secondary"><th colspan="2">license<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/license">http://purl.org/dc/terms/license</a></td></tr>
                                 <tr><td class="label">Definition</td><td>A legal document giving official permission to do something with the resource.</td></tr>
-                                <tr><td class="label">Comments</td><td>Examples: <code><a href="http://creativecommons.org/publicdomain/zero/1.0/legalcode">http://creativecommons.org/publicdomain/zero/1.0/legalcode</a></code>, <code><a href="http://creativecommons.org/licenses/by/4.0/legalcode">http://creativecommons.org/licenses/by/4.0/legalcode</a></code>. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:license">http://terms.tdwg.org/wiki/dwc:license</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>Examples: <code><a href="http://creativecommons.org/publicdomain/zero/1.0/legalcode">http://creativecommons.org/publicdomain/zero/1.0/legalcode</a></code>, <code><a href="http://creativecommons.org/licenses/by/4.0/legalcode">http://creativecommons.org/licenses/by/4.0/legalcode</a></code>. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:license">http://terms.tdwg.org/wiki/dcterms:license</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -227,7 +227,7 @@
                                 <tr class="table-secondary"><th colspan="2">rightsHolder<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/rightsHolder">http://purl.org/dc/terms/rightsHolder</a></td></tr>
                                 <tr><td class="label">Definition</td><td>A person or organization owning or managing rights over the resource.</td></tr>
-                                <tr><td class="label">Comments</td><td>Example: <code>The Regents of the University of California</code>. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:rightsHolder">http://terms.tdwg.org/wiki/dwc:rightsHolder</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>Example: <code>The Regents of the University of California</code>. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:rightsHolder">http://terms.tdwg.org/wiki/dcterms:rightsHolder</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -237,7 +237,7 @@
                                 <tr class="table-secondary"><th colspan="2">accessRights<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/accessRights">http://purl.org/dc/terms/accessRights</a></td></tr>
                                 <tr><td class="label">Definition</td><td>Information about who can access the resource or an indication of its security status. Access Rights may include information regarding access or restrictions based on privacy, security, or other policies.</td></tr>
-                                <tr><td class="label">Comments</td><td>Example: <code>not-for-profit use only</code>. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:accessRights">http://terms.tdwg.org/wiki/dwc:accessRights</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>Example: <code>not-for-profit use only</code>. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:accessRights">http://terms.tdwg.org/wiki/dcterms:accessRights</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -247,7 +247,7 @@
                                 <tr class="table-secondary"><th colspan="2">bibliographicCitation<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/bibliographicCitation">http://purl.org/dc/terms/bibliographicCitation</a></td></tr>
                                 <tr><td class="label">Definition</td><td>A bibliographic reference for the resource as a statement indicating how this record should be cited (attributed) when used.</td></tr>
-                                <tr><td class="label">Comments</td><td>Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible. Examples: <code>Ctenomys sociabilis (MVZ 165861)</code> for a specimen, <code>Oliver P. Pearson. 1985. Los tuco-tucos (genera Ctenomys) de los Parques Nacionales Lanin y Nahuel Huapi, Argentina Historia Natural, 5(37):337-343.</code> for a Taxon. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:bibliographicCitation">http://terms.tdwg.org/wiki/dwc:bibliographicCitation</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible. Examples: <code>Ctenomys sociabilis (MVZ 165861)</code> for a specimen, <code>Oliver P. Pearson. 1985. Los tuco-tucos (genera Ctenomys) de los Parques Nacionales Lanin y Nahuel Huapi, Argentina Historia Natural, 5(37):337-343.</code> for a Taxon. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:bibliographicCitation">http://terms.tdwg.org/wiki/dcterms:bibliographicCitation</a>.</td></tr>
                             </tbody>
                         </table>
                         
@@ -257,7 +257,7 @@
                                 <tr class="table-secondary"><th colspan="2">references<span class="badge badge-secondary float-right">Property</span></th></tr>
                                 <tr><td class="label">Identifier</td><td><a href="http://purl.org/dc/terms/references">http://purl.org/dc/terms/references</a></td></tr>
                                 <tr><td class="label">Definition</td><td>A related resource that is referenced, cited, or otherwise pointed to by the described resource.</td></tr>
-                                <tr><td class="label">Comments</td><td>Examples: <code><a href="http://mvzarctos.berkeley.edu/guid/MVZ:Mamm:165861">http://mvzarctos.berkeley.edu/guid/MVZ:Mamm:165861</a></code>, <code><a href="http://www.catalogueoflife.org/annual-checklist/show_species_details.php?record_id=6197868">http://www.catalogueoflife.org/annual-checklist/show_species_details.php?record_id=6197868</a></code>. For discussion see <a href="http://terms.tdwg.org/wiki/dwc:references">http://terms.tdwg.org/wiki/dwc:references</a>.</td></tr>
+                                <tr><td class="label">Comments</td><td>Examples: <code><a href="http://mvzarctos.berkeley.edu/guid/MVZ:Mamm:165861">http://mvzarctos.berkeley.edu/guid/MVZ:Mamm:165861</a></code>, <code><a href="http://www.catalogueoflife.org/annual-checklist/show_species_details.php?record_id=6197868">http://www.catalogueoflife.org/annual-checklist/show_species_details.php?record_id=6197868</a></code>. For discussion see <a href="http://terms.tdwg.org/wiki/dcterms:references">http://terms.tdwg.org/wiki/dcterms:references</a>.</td></tr>
                             </tbody>
                         </table>
                         


### PR DESCRIPTION
Noticed that the linkes in "Comments" for the dcterms point to the correct term names but prefixed by "dwc" instead of "dcterms". The links thus does not work. Eg. http://terms.tdwg.org/wiki/dwc:type should be _[http://terms.tdwg.org/wiki/dcterms:type](http://terms.tdwg.org/wiki/dcterms:type)_

I have also submitted a corresponding proposed update to the document: dwc/build/config/terms.csv
I assume the terms.tdwg.org links originates from that document?