### PR TITLE
CV proofreading regenerate lists of terms docs

### DIFF
--- a/build/doe-cv-build/doe_build.py
+++ b/build/doe-cv-build/doe_build.py
@@ -1,0 +1,325 @@
+# Script to build Markdown pages that provide term metadata for simple vocabularies
+# Steve Baskauf 2020-06-28 CC0
+# This script merges static Markdown header and footer documents with term information tables (in Markdown) generated from data in the rs.tdwg.org repo from the TDWG Github site
+
+# Note: this script calls a function from http_library.py, which requires importing the requests, csv, and json modules
+import re
+import requests   # best library to manage HTTP transactions
+import csv        # library to read/write/parse CSV files
+import json       # library to convert JSON to Python data structures
+import pandas as pd
+
+# -----------------
+# Configuration section
+# -----------------
+
+# !!!! Note !!!!
+# This is an example of a simple vocabulary without categories. For a complex example
+# with multiple namespaces and several categories, see build-page-categories.ipynb
+
+# This is the base URL for raw files from the branch of the repo that has been pushed to GitHub. In this example,
+# the branch is named "pathway"
+githubBaseUri = 'https://raw.githubusercontent.com/tdwg/rs.tdwg.org/master/'
+
+headerFileName = 'termlist-header.md'
+footerFileName = 'termlist-footer.md'
+outFileName = '../../docs/doe/index.md'
+
+# This is a Python list of the database names of the term lists to be included in the document.
+termLists = ['degreeOfEstablishment']
+
+# NOTE! There may be problems unless every term list is of the same vocabulary type since the number of columns will differ
+# However, there probably aren't any circumstances where mixed types will be used to generate the same page.
+vocab_type = 2 # 1 is simple vocabulary, 2 is simple controlled vocabulary, 3 is c.v. with broader hierarchy
+
+# Terms in large vocabularies like Darwin and Audubon Cores may be organized into categories using tdwgutility_organizedInClass
+# If so, those categories can be used to group terms in the generated term list document.
+organized_in_categories = False
+
+# If organized in categories, the display_order list must contain the IRIs that are values of tdwgutility_organizedInClass
+# If not organized into categories, the value is irrelevant. There just needs to be one item in the list.
+display_order = ['']
+display_label = ['Vocabulary'] # these are the section labels for the categories in the page
+display_comments = [''] # these are the comments about the category to be appended following the section labels
+display_id = ['Vocabulary'] # these are the fragment identifiers for the associated sections for the categories
+
+# ---------------
+# Function definitions
+# ---------------
+
+# replace URL with link
+#
+def createLinks(text):
+    def repl(match):
+        if match.group(1)[-1] == '.':
+            return '<a href="' + match.group(1)[:-1] + '">' + match.group(1)[:-1] + '</a>.'
+        return '<a href="' + match.group(1) + '">' + match.group(1) + '</a>'
+
+    pattern = '(https?://[^\s,;\)"]*)'
+    result = re.sub(pattern, repl, text)
+    return result
+
+# 2021-08-06 Replace the createLinks() function with functions copied from the QRG build script written by S. Van Hoey
+def convert_code(text_with_backticks):
+    """Takes all back-quoted sections in a text field and converts it to
+    the html tagged version of code blocks <code>...</code>
+    """
+    return re.sub(r'`([^`]*)`', r'<code>\1</code>', text_with_backticks)
+
+def convert_link(text_with_urls):
+    """Takes all links in a text field and converts it to the html tagged
+    version of the link
+    """
+    def _handle_matched(inputstring):
+        """quick hack version of url handling on the current prime versions data"""
+        url = inputstring.group()
+        return "<a href=\"{}\">{}</a>".format(url, url)
+
+    regx = "(http[s]?://[\w\d:#@%/;$()~_?\+-;=\\\.&]*)(?<![\)\.,])"
+    return re.sub(regx, _handle_matched, text_with_urls)
+
+term_lists_info = []
+
+frame = pd.read_csv(githubBaseUri + 'term-lists/term-lists.csv', na_filter=False)
+for termList in termLists:
+    term_list_dict = {'list_iri': termList}
+    term_list_dict = {'database': termList}
+    for index,row in frame.iterrows():
+        if row['database'] == termList:
+            term_list_dict['pref_ns_prefix'] = row['vann_preferredNamespacePrefix']
+            term_list_dict['pref_ns_uri'] = row['vann_preferredNamespaceUri']
+            term_list_dict['list_iri'] = row['list']
+    term_lists_info.append(term_list_dict)
+
+# Create column list
+column_list = ['pref_ns_prefix', 'pref_ns_uri', 'term_localName', 'label', 'definition', 'usage', 'notes', 'term_modified', 'term_deprecated', 'type']
+if vocab_type == 2:
+    column_list += ['controlled_value_string']
+elif vocab_type == 3:
+    column_list += ['controlled_value_string', 'skos_broader']
+if organized_in_categories:
+    column_list.append('tdwgutility_organizedInClass')
+column_list.append('version_iri')
+
+# Create list of lists metadata table
+table_list = []
+for term_list in term_lists_info:
+    # retrieve versions metadata for term list
+    versions_url = githubBaseUri + term_list['database'] + '-versions/' + term_list['database'] + '-versions.csv'
+    versions_df = pd.read_csv(versions_url, na_filter=False)
+    
+    # retrieve current term metadata for term list
+    data_url = githubBaseUri + term_list['database'] + '/' + term_list['database'] + '.csv'
+    frame = pd.read_csv(data_url, na_filter=False)
+    for index,row in frame.iterrows():
+        row_list = [term_list['pref_ns_prefix'], term_list['pref_ns_uri'], row['term_localName'], row['label'], row['definition'], row['usage'], row['notes'], row['term_modified'], row['term_deprecated'], row['type']]
+        if vocab_type == 2:
+            row_list += [row['controlled_value_string']]
+        elif vocab_type == 3:
+            if row['skos_broader'] =='':
+                row_list += [row['controlled_value_string'], '']
+            else:
+                row_list += [row['controlled_value_string'], term_list['pref_ns_prefix'] + ':' + row['skos_broader']]
+        if organized_in_categories:
+            row_list.append(row['tdwgutility_organizedInClass'])
+
+        # Borrowed terms really don't have implemented versions. They may be lacking values for version_status.
+        # In their case, their version IRI will be omitted.
+        found = False
+        for vindex, vrow in versions_df.iterrows():
+            if vrow['term_localName']==row['term_localName'] and vrow['version_status']=='recommended':
+                found = True
+                version_iri = vrow['version']
+                # NOTE: the current hack for non-TDWG terms without a version is to append # to the end of the term IRI
+                if version_iri[len(version_iri)-1] == '#':
+                    version_iri = ''
+        if not found:
+            version_iri = ''
+        row_list.append(version_iri)
+
+        table_list.append(row_list)
+
+# Turn list of lists into dataframe
+terms_df = pd.DataFrame(table_list, columns = column_list)
+
+terms_sorted_by_label = terms_df.sort_values(by='label')
+terms_sorted_by_localname = terms_df.sort_values(by='term_localName')
+terms_sorted_by_label
+
+# generate the index of terms grouped by category and sorted alphabetically by lowercase term local name
+
+text = '### 3.1 Index By Term Name\n\n'
+text += '(See also [3.2 Index By Label](#32-index-by-label))\n\n'
+for category in range(0,len(display_order)):
+    text += '**' + display_label[category] + '**\n'
+    text += '\n'
+    if organized_in_categories:
+        filtered_table = terms_sorted_by_localname[terms_sorted_by_localname['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_localname
+        filtered_table.reset_index(drop=True, inplace=True)
+        
+    for row_index,row in filtered_table.iterrows():
+        curie = row['pref_ns_prefix'] + ":" + row['term_localName']
+        curie_anchor = curie.replace(':','_')
+        text += '[' + curie + '](#' + curie_anchor + ')'
+        if row_index < len(filtered_table) - 1:
+            text += ' |'
+        text += '\n'
+    text += '\n'
+index_by_name = text
+
+text = '\n\n'
+
+# Comment out the following two lines if there is no index by local names
+#text = '### 3.2 Index By Label\n\n'
+#text += '(See also [3.1 Index By Term Name](#31-index-by-term-name))\n\n'
+for category in range(0,len(display_order)):
+    if organized_in_categories:
+        text += '**' + display_label[category] + '**\n'
+        text += '\n'
+        filtered_table = terms_sorted_by_label[terms_sorted_by_label['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_label
+        filtered_table.reset_index(drop=True, inplace=True)
+        
+    for row_index,row in filtered_table.iterrows():
+        if row_index == 0 or (row_index != 0 and row['label'] != filtered_table.iloc[row_index - 1].loc['label']): # this is a hack to prevent duplicate labels
+            curie_anchor = row['pref_ns_prefix'] + "_" + row['term_localName']
+            text += '[' + row['label'] + '](#' + curie_anchor + ')'
+            if row_index < len(filtered_table) - 2 or (row_index == len(filtered_table) - 2 and row['label'] != filtered_table.iloc[row_index + 1].loc['label']):
+                text += ' |'
+            text += '\n'
+    text += '\n'
+index_by_label = text
+
+decisions_df = pd.read_csv('https://raw.githubusercontent.com/tdwg/rs.tdwg.org/master/decisions/decisions-links.csv', na_filter=False)
+
+# generate a table for each term, with terms grouped by category
+
+# generate the Markdown for the terms table
+text = '## 4 Vocabulary\n'
+for category in range(0,len(display_order)):
+    if organized_in_categories:
+        text += '### 4.' + str(category + 1) + ' ' + display_label[category] + '\n'
+        text += '\n'
+        text += display_comments[category] # insert the comments for the category, if any.
+        filtered_table = terms_sorted_by_localname[terms_sorted_by_localname['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_localname
+        filtered_table.reset_index(drop=True, inplace=True)
+
+    for row_index,row in filtered_table.iterrows():
+        text += '<table>\n'
+        curie = row['pref_ns_prefix'] + ":" + row['term_localName']
+        curieAnchor = curie.replace(':','_')
+        text += '\t<thead>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<th colspan="2"><a id="' + curieAnchor + '"></a>Term Name  ' + curie + '</th>\n'
+        text += '\t\t</tr>\n'
+        text += '\t</thead>\n'
+        text += '\t<tbody>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Term IRI</td>\n'
+        uri = row['pref_ns_uri'] + row['term_localName']
+        text += '\t\t\t<td><a href="' + uri + '">' + uri + '</a></td>\n'
+        text += '\t\t</tr>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Modified</td>\n'
+        text += '\t\t\t<td>' + row['term_modified'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['version_iri'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Term version IRI</td>\n'
+            text += '\t\t\t<td><a href="' + row['version_iri'] + '">' + row['version_iri'] + '</a></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Label</td>\n'
+        text += '\t\t\t<td>' + row['label'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['term_deprecated'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td></td>\n'
+            text += '\t\t\t<td><strong>This term is deprecated and should no longer be used.</strong></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Definition</td>\n'
+        text += '\t\t\t<td>' + row['definition'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['usage'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Usage</td>\n'
+            text += '\t\t\t<td>' + convert_link(convert_code(row['usage'])) + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if row['notes'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Notes</td>\n'
+            text += '\t\t\t<td>' + convert_link(convert_code(row['notes'])) + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if (vocab_type == 2 or vocab_type == 3) and row['controlled_value_string'] != '': # controlled vocabulary
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Controlled value</td>\n'
+            text += '\t\t\t<td>' + row['controlled_value_string'] + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if vocab_type == 3 and row['skos_broader'] != '': # controlled vocabulary with skos:broader relationships
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Has broader concept</td>\n'
+            curieAnchor = row['skos_broader'].replace(':','_')
+            text += '\t\t\t<td><a href="#' + curieAnchor + '">' + row['skos_broader'] + '</a></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Type</td>\n'
+        if row['type'] == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#Property':
+            text += '\t\t\t<td>Property</td>\n'
+        elif row['type'] == 'http://www.w3.org/2000/01/rdf-schema#Class':
+            text += '\t\t\t<td>Class</td>\n'
+        elif row['type'] == 'http://www.w3.org/2004/02/skos/core#Concept':
+            text += '\t\t\t<td>Concept</td>\n'
+        else:
+            text += '\t\t\t<td>' + row['type'] + '</td>\n' # this should rarely happen
+        text += '\t\t</tr>\n'
+
+        # Look up decisions related to this term
+        for drow_index,drow in decisions_df.iterrows():
+            if drow['linked_affected_resource'] == uri:
+                text += '\t\t<tr>\n'
+                text += '\t\t\t<td>Executive Committee decision</td>\n'
+                text += '\t\t\t<td><a href="http://rs.tdwg.org/decisions/' + drow['decision_localName'] + '">http://rs.tdwg.org/decisions/' + drow['decision_localName'] + '</a></td>\n'
+                text += '\t\t</tr>\n'                        
+
+        text += '\t</tbody>\n'
+        text += '</table>\n'
+        text += '\n'
+    text += '\n'
+term_table = text
+
+text = index_by_label + term_table
+
+# read in header and footer, merge with terms table, and output
+
+headerObject = open(headerFileName, 'rt', encoding='utf-8')
+header = headerObject.read()
+headerObject.close()
+
+footerObject = open(footerFileName, 'rt', encoding='utf-8')
+footer = footerObject.read()
+footerObject.close()
+
+output = header + text + footer
+outputObject = open(outFileName, 'wt', encoding='utf-8')
+outputObject.write(output)
+outputObject.close()
+    
+print('done')

--- a/build/doe-cv-build/termlist-header.md
+++ b/build/doe-cv-build/termlist-header.md
@@ -10,7 +10,7 @@ Preferred namespace abbreviation
 : dwcdoe:
 
 Date version issued
-: 2020-10-13
+: 2021-09-01
 
 Date created
 : 2020-10-13
@@ -19,10 +19,13 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This document version
-: <http://rs.tdwg.org/dwc/doc/doe/2020-10-13>
+: <http://rs.tdwg.org/dwc/doc/doe/2021-09-01>
 
 Latest version of document
 : <http://rs.tdwg.org/dwc/doc/doe/>
+
+Previous version
+: <http://rs.tdwg.org/dwc/doc/doe/2020-10-13>
 
 Abstract
 : The Darwin Core term `degreeOfEstablishment` provides information about degree to which an Organism survives, reproduces, and expands its range at the given place and time.. The Degree of Establishment Controlled Vocabulary provides terms that should be used as values for `dwc:degreeOfEstablishment` and `dwciri:degreeOfEstablishment`. 
@@ -34,7 +37,7 @@ Creator
 : TDWG Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2020. Degree of Establishment Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/doe/2020-10-13>
+: Darwin Core Maintenance Group. 2021. Degree of Establishment Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/doe/2021-09-01>
 
 
 ## 1 Introduction

--- a/build/em-cv-build/em_build.py
+++ b/build/em-cv-build/em_build.py
@@ -1,0 +1,325 @@
+# Script to build Markdown pages that provide term metadata for simple vocabularies
+# Steve Baskauf 2020-06-28 CC0
+# This script merges static Markdown header and footer documents with term information tables (in Markdown) generated from data in the rs.tdwg.org repo from the TDWG Github site
+
+# Note: this script calls a function from http_library.py, which requires importing the requests, csv, and json modules
+import re
+import requests   # best library to manage HTTP transactions
+import csv        # library to read/write/parse CSV files
+import json       # library to convert JSON to Python data structures
+import pandas as pd
+
+# -----------------
+# Configuration section
+# -----------------
+
+# !!!! Note !!!!
+# This is an example of a simple vocabulary without categories. For a complex example
+# with multiple namespaces and several categories, see build-page-categories.ipynb
+
+# This is the base URL for raw files from the branch of the repo that has been pushed to GitHub. In this example,
+# the branch is named "pathway"
+githubBaseUri = 'https://raw.githubusercontent.com/tdwg/rs.tdwg.org/master/'
+
+headerFileName = 'termlist-header.md'
+footerFileName = 'termlist-footer.md'
+outFileName = '../../docs/em/index.md'
+
+# This is a Python list of the database names of the term lists to be included in the document.
+termLists = ['establishmentMeans']
+
+# NOTE! There may be problems unless every term list is of the same vocabulary type since the number of columns will differ
+# However, there probably aren't any circumstances where mixed types will be used to generate the same page.
+vocab_type = 2 # 1 is simple vocabulary, 2 is simple controlled vocabulary, 3 is c.v. with broader hierarchy
+
+# Terms in large vocabularies like Darwin and Audubon Cores may be organized into categories using tdwgutility_organizedInClass
+# If so, those categories can be used to group terms in the generated term list document.
+organized_in_categories = False
+
+# If organized in categories, the display_order list must contain the IRIs that are values of tdwgutility_organizedInClass
+# If not organized into categories, the value is irrelevant. There just needs to be one item in the list.
+display_order = ['']
+display_label = ['Vocabulary'] # these are the section labels for the categories in the page
+display_comments = [''] # these are the comments about the category to be appended following the section labels
+display_id = ['Vocabulary'] # these are the fragment identifiers for the associated sections for the categories
+
+# ---------------
+# Function definitions
+# ---------------
+
+# replace URL with link
+#
+def createLinks(text):
+    def repl(match):
+        if match.group(1)[-1] == '.':
+            return '<a href="' + match.group(1)[:-1] + '">' + match.group(1)[:-1] + '</a>.'
+        return '<a href="' + match.group(1) + '">' + match.group(1) + '</a>'
+
+    pattern = '(https?://[^\s,;\)"]*)'
+    result = re.sub(pattern, repl, text)
+    return result
+
+# 2021-08-06 Replace the createLinks() function with functions copied from the QRG build script written by S. Van Hoey
+def convert_code(text_with_backticks):
+    """Takes all back-quoted sections in a text field and converts it to
+    the html tagged version of code blocks <code>...</code>
+    """
+    return re.sub(r'`([^`]*)`', r'<code>\1</code>', text_with_backticks)
+
+def convert_link(text_with_urls):
+    """Takes all links in a text field and converts it to the html tagged
+    version of the link
+    """
+    def _handle_matched(inputstring):
+        """quick hack version of url handling on the current prime versions data"""
+        url = inputstring.group()
+        return "<a href=\"{}\">{}</a>".format(url, url)
+
+    regx = "(http[s]?://[\w\d:#@%/;$()~_?\+-;=\\\.&]*)(?<![\)\.,])"
+    return re.sub(regx, _handle_matched, text_with_urls)
+
+term_lists_info = []
+
+frame = pd.read_csv(githubBaseUri + 'term-lists/term-lists.csv', na_filter=False)
+for termList in termLists:
+    term_list_dict = {'list_iri': termList}
+    term_list_dict = {'database': termList}
+    for index,row in frame.iterrows():
+        if row['database'] == termList:
+            term_list_dict['pref_ns_prefix'] = row['vann_preferredNamespacePrefix']
+            term_list_dict['pref_ns_uri'] = row['vann_preferredNamespaceUri']
+            term_list_dict['list_iri'] = row['list']
+    term_lists_info.append(term_list_dict)
+
+# Create column list
+column_list = ['pref_ns_prefix', 'pref_ns_uri', 'term_localName', 'label', 'definition', 'usage', 'notes', 'term_modified', 'term_deprecated', 'type']
+if vocab_type == 2:
+    column_list += ['controlled_value_string']
+elif vocab_type == 3:
+    column_list += ['controlled_value_string', 'skos_broader']
+if organized_in_categories:
+    column_list.append('tdwgutility_organizedInClass')
+column_list.append('version_iri')
+
+# Create list of lists metadata table
+table_list = []
+for term_list in term_lists_info:
+    # retrieve versions metadata for term list
+    versions_url = githubBaseUri + term_list['database'] + '-versions/' + term_list['database'] + '-versions.csv'
+    versions_df = pd.read_csv(versions_url, na_filter=False)
+    
+    # retrieve current term metadata for term list
+    data_url = githubBaseUri + term_list['database'] + '/' + term_list['database'] + '.csv'
+    frame = pd.read_csv(data_url, na_filter=False)
+    for index,row in frame.iterrows():
+        row_list = [term_list['pref_ns_prefix'], term_list['pref_ns_uri'], row['term_localName'], row['label'], row['definition'], row['usage'], row['notes'], row['term_modified'], row['term_deprecated'], row['type']]
+        if vocab_type == 2:
+            row_list += [row['controlled_value_string']]
+        elif vocab_type == 3:
+            if row['skos_broader'] =='':
+                row_list += [row['controlled_value_string'], '']
+            else:
+                row_list += [row['controlled_value_string'], term_list['pref_ns_prefix'] + ':' + row['skos_broader']]
+        if organized_in_categories:
+            row_list.append(row['tdwgutility_organizedInClass'])
+
+        # Borrowed terms really don't have implemented versions. They may be lacking values for version_status.
+        # In their case, their version IRI will be omitted.
+        found = False
+        for vindex, vrow in versions_df.iterrows():
+            if vrow['term_localName']==row['term_localName'] and vrow['version_status']=='recommended':
+                found = True
+                version_iri = vrow['version']
+                # NOTE: the current hack for non-TDWG terms without a version is to append # to the end of the term IRI
+                if version_iri[len(version_iri)-1] == '#':
+                    version_iri = ''
+        if not found:
+            version_iri = ''
+        row_list.append(version_iri)
+
+        table_list.append(row_list)
+
+# Turn list of lists into dataframe
+terms_df = pd.DataFrame(table_list, columns = column_list)
+
+terms_sorted_by_label = terms_df.sort_values(by='label')
+terms_sorted_by_localname = terms_df.sort_values(by='term_localName')
+terms_sorted_by_label
+
+# generate the index of terms grouped by category and sorted alphabetically by lowercase term local name
+
+text = '### 3.1 Index By Term Name\n\n'
+text += '(See also [3.2 Index By Label](#32-index-by-label))\n\n'
+for category in range(0,len(display_order)):
+    text += '**' + display_label[category] + '**\n'
+    text += '\n'
+    if organized_in_categories:
+        filtered_table = terms_sorted_by_localname[terms_sorted_by_localname['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_localname
+        filtered_table.reset_index(drop=True, inplace=True)
+        
+    for row_index,row in filtered_table.iterrows():
+        curie = row['pref_ns_prefix'] + ":" + row['term_localName']
+        curie_anchor = curie.replace(':','_')
+        text += '[' + curie + '](#' + curie_anchor + ')'
+        if row_index < len(filtered_table) - 1:
+            text += ' |'
+        text += '\n'
+    text += '\n'
+index_by_name = text
+
+text = '\n\n'
+
+# Comment out the following two lines if there is no index by local names
+#text = '### 3.2 Index By Label\n\n'
+#text += '(See also [3.1 Index By Term Name](#31-index-by-term-name))\n\n'
+for category in range(0,len(display_order)):
+    if organized_in_categories:
+        text += '**' + display_label[category] + '**\n'
+        text += '\n'
+        filtered_table = terms_sorted_by_label[terms_sorted_by_label['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_label
+        filtered_table.reset_index(drop=True, inplace=True)
+        
+    for row_index,row in filtered_table.iterrows():
+        if row_index == 0 or (row_index != 0 and row['label'] != filtered_table.iloc[row_index - 1].loc['label']): # this is a hack to prevent duplicate labels
+            curie_anchor = row['pref_ns_prefix'] + "_" + row['term_localName']
+            text += '[' + row['label'] + '](#' + curie_anchor + ')'
+            if row_index < len(filtered_table) - 2 or (row_index == len(filtered_table) - 2 and row['label'] != filtered_table.iloc[row_index + 1].loc['label']):
+                text += ' |'
+            text += '\n'
+    text += '\n'
+index_by_label = text
+
+decisions_df = pd.read_csv('https://raw.githubusercontent.com/tdwg/rs.tdwg.org/master/decisions/decisions-links.csv', na_filter=False)
+
+# generate a table for each term, with terms grouped by category
+
+# generate the Markdown for the terms table
+text = '## 4 Vocabulary\n'
+for category in range(0,len(display_order)):
+    if organized_in_categories:
+        text += '### 4.' + str(category + 1) + ' ' + display_label[category] + '\n'
+        text += '\n'
+        text += display_comments[category] # insert the comments for the category, if any.
+        filtered_table = terms_sorted_by_localname[terms_sorted_by_localname['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_localname
+        filtered_table.reset_index(drop=True, inplace=True)
+
+    for row_index,row in filtered_table.iterrows():
+        text += '<table>\n'
+        curie = row['pref_ns_prefix'] + ":" + row['term_localName']
+        curieAnchor = curie.replace(':','_')
+        text += '\t<thead>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<th colspan="2"><a id="' + curieAnchor + '"></a>Term Name  ' + curie + '</th>\n'
+        text += '\t\t</tr>\n'
+        text += '\t</thead>\n'
+        text += '\t<tbody>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Term IRI</td>\n'
+        uri = row['pref_ns_uri'] + row['term_localName']
+        text += '\t\t\t<td><a href="' + uri + '">' + uri + '</a></td>\n'
+        text += '\t\t</tr>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Modified</td>\n'
+        text += '\t\t\t<td>' + row['term_modified'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['version_iri'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Term version IRI</td>\n'
+            text += '\t\t\t<td><a href="' + row['version_iri'] + '">' + row['version_iri'] + '</a></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Label</td>\n'
+        text += '\t\t\t<td>' + row['label'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['term_deprecated'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td></td>\n'
+            text += '\t\t\t<td><strong>This term is deprecated and should no longer be used.</strong></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Definition</td>\n'
+        text += '\t\t\t<td>' + row['definition'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['usage'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Usage</td>\n'
+            text += '\t\t\t<td>' + convert_link(convert_code(row['usage'])) + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if row['notes'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Notes</td>\n'
+            text += '\t\t\t<td>' + convert_link(convert_code(row['notes'])) + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if (vocab_type == 2 or vocab_type == 3) and row['controlled_value_string'] != '': # controlled vocabulary
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Controlled value</td>\n'
+            text += '\t\t\t<td>' + row['controlled_value_string'] + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if vocab_type == 3 and row['skos_broader'] != '': # controlled vocabulary with skos:broader relationships
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Has broader concept</td>\n'
+            curieAnchor = row['skos_broader'].replace(':','_')
+            text += '\t\t\t<td><a href="#' + curieAnchor + '">' + row['skos_broader'] + '</a></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Type</td>\n'
+        if row['type'] == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#Property':
+            text += '\t\t\t<td>Property</td>\n'
+        elif row['type'] == 'http://www.w3.org/2000/01/rdf-schema#Class':
+            text += '\t\t\t<td>Class</td>\n'
+        elif row['type'] == 'http://www.w3.org/2004/02/skos/core#Concept':
+            text += '\t\t\t<td>Concept</td>\n'
+        else:
+            text += '\t\t\t<td>' + row['type'] + '</td>\n' # this should rarely happen
+        text += '\t\t</tr>\n'
+
+        # Look up decisions related to this term
+        for drow_index,drow in decisions_df.iterrows():
+            if drow['linked_affected_resource'] == uri:
+                text += '\t\t<tr>\n'
+                text += '\t\t\t<td>Executive Committee decision</td>\n'
+                text += '\t\t\t<td><a href="http://rs.tdwg.org/decisions/' + drow['decision_localName'] + '">http://rs.tdwg.org/decisions/' + drow['decision_localName'] + '</a></td>\n'
+                text += '\t\t</tr>\n'                        
+
+        text += '\t</tbody>\n'
+        text += '</table>\n'
+        text += '\n'
+    text += '\n'
+term_table = text
+
+text = index_by_label + term_table
+
+# read in header and footer, merge with terms table, and output
+
+headerObject = open(headerFileName, 'rt', encoding='utf-8')
+header = headerObject.read()
+headerObject.close()
+
+footerObject = open(footerFileName, 'rt', encoding='utf-8')
+footer = footerObject.read()
+footerObject.close()
+
+output = header + text + footer
+outputObject = open(outFileName, 'wt', encoding='utf-8')
+outputObject.write(output)
+outputObject.close()
+    
+print('done')

--- a/build/em-cv-build/termlist-header.md
+++ b/build/em-cv-build/termlist-header.md
@@ -10,7 +10,7 @@ Preferred namespace abbreviation
 : dwcem:
 
 Date version issued
-: 2020-10-13
+: 2021-09-01
 
 Date created
 : 2020-10-13
@@ -19,10 +19,13 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This document version
-: <http://rs.tdwg.org/dwc/doc/em/2020-10-13>
+: <http://rs.tdwg.org/dwc/doc/em/2021-09-01>
 
 Latest version of document
 : <http://rs.tdwg.org/dwc/doc/em/>
+
+Previous version
+: <http://rs.tdwg.org/dwc/doc/em/2020-10-13>
 
 Abstract
 : The Darwin Core term `establishmentMeans` provides information about whether an organism or organisms have been introduced to a given place and time through the direct or indirect activity of modern humans. The Establishment Means Controlled Vocabulary provides terms that should be used as values for `dwc:establishmentMeans` and `dwciri:establishmentMeans`. 
@@ -34,7 +37,7 @@ Creator
 : TDWG Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2020. Establishment Means Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/em/2020-10-13>
+: Darwin Core Maintenance Group. 2021. Establishment Means Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/em/2021-09-01>
 
 
 ## 1 Introduction

--- a/build/pw-cv-build/pw_build.py
+++ b/build/pw-cv-build/pw_build.py
@@ -1,0 +1,326 @@
+# Script to build Markdown pages that provide term metadata for simple vocabularies
+# Steve Baskauf 2020-06-28 CC0
+# This script merges static Markdown header and footer documents with term information tables (in Markdown) generated from data in the rs.tdwg.org repo from the TDWG Github site
+
+# Note: this script calls a function from http_library.py, which requires importing the requests, csv, and json modules
+import re
+import requests   # best library to manage HTTP transactions
+import csv        # library to read/write/parse CSV files
+import json       # library to convert JSON to Python data structures
+import pandas as pd
+
+# -----------------
+# Configuration section
+# -----------------
+
+# !!!! Note !!!!
+# This is an example of a simple vocabulary without categories. For a complex example
+# with multiple namespaces and several categories, see build-page-categories.ipynb
+
+# This is the base URL for raw files from the branch of the repo that has been pushed to GitHub. In this example,
+# the branch is named "pathway"
+githubBaseUri = 'https://raw.githubusercontent.com/tdwg/rs.tdwg.org/master/'
+
+headerFileName = 'termlist-header.md'
+footerFileName = 'termlist-footer.md'
+outFileName = '../../docs/pw/index.md'
+
+# This is a Python list of the database names of the term lists to be included in the document.
+termLists = ['pathway']
+
+# NOTE! There may be problems unless every term list is of the same vocabulary type since the number of columns will differ
+# However, there probably aren't any circumstances where mixed types will be used to generate the same page.
+vocab_type = 3 # 1 is simple vocabulary, 2 is simple controlled vocabulary, 3 is c.v. with broader hierarchy
+
+# Terms in large vocabularies like Darwin and Audubon Cores may be organized into categories using tdwgutility_organizedInClass
+# If so, those categories can be used to group terms in the generated term list document.
+organized_in_categories = False
+
+# If organized in categories, the display_order list must contain the IRIs that are values of tdwgutility_organizedInClass
+# If not organized into categories, the value is irrelevant. There just needs to be one item in the list.
+display_order = ['']
+display_label = ['Vocabulary'] # these are the section labels for the categories in the page
+display_comments = [''] # these are the comments about the category to be appended following the section labels
+display_id = ['Vocabulary'] # these are the fragment identifiers for the associated sections for the categories
+
+# ---------------
+# Function definitions
+# ---------------
+
+# replace URL with link
+#
+def createLinks(text):
+    def repl(match):
+        if match.group(1)[-1] == '.':
+            return '<a href="' + match.group(1)[:-1] + '">' + match.group(1)[:-1] + '</a>.'
+        return '<a href="' + match.group(1) + '">' + match.group(1) + '</a>'
+
+    pattern = '(https?://[^\s,;\)"]*)'
+    result = re.sub(pattern, repl, text)
+    return result
+
+# 2021-08-06 Replace the createLinks() function with functions copied from the QRG build script written by S. Van Hoey
+def convert_code(text_with_backticks):
+    """Takes all back-quoted sections in a text field and converts it to
+    the html tagged version of code blocks <code>...</code>
+    """
+    return re.sub(r'`([^`]*)`', r'<code>\1</code>', text_with_backticks)
+
+def convert_link(text_with_urls):
+    """Takes all links in a text field and converts it to the html tagged
+    version of the link
+    """
+    def _handle_matched(inputstring):
+        """quick hack version of url handling on the current prime versions data"""
+        url = inputstring.group()
+        return "<a href=\"{}\">{}</a>".format(url, url)
+
+    regx = "(http[s]?://[\w\d:#@%/;$()~_?\+-;=\\\.&]*)(?<![\)\.,])"
+    return re.sub(regx, _handle_matched, text_with_urls)
+
+term_lists_info = []
+
+frame = pd.read_csv(githubBaseUri + 'term-lists/term-lists.csv', na_filter=False)
+for termList in termLists:
+    term_list_dict = {'list_iri': termList}
+    term_list_dict = {'database': termList}
+    for index,row in frame.iterrows():
+        if row['database'] == termList:
+            term_list_dict['pref_ns_prefix'] = row['vann_preferredNamespacePrefix']
+            term_list_dict['pref_ns_uri'] = row['vann_preferredNamespaceUri']
+            term_list_dict['list_iri'] = row['list']
+    term_lists_info.append(term_list_dict)
+
+# Create column list
+column_list = ['pref_ns_prefix', 'pref_ns_uri', 'term_localName', 'label', 'definition', 'usage', 'notes', 'term_modified', 'term_deprecated', 'type']
+if vocab_type == 2:
+    column_list += ['controlled_value_string']
+elif vocab_type == 3:
+    column_list += ['controlled_value_string', 'skos_broader']
+if organized_in_categories:
+    column_list.append('tdwgutility_organizedInClass')
+column_list.append('version_iri')
+
+# Create list of lists metadata table
+table_list = []
+for term_list in term_lists_info:
+    # retrieve versions metadata for term list
+    versions_url = githubBaseUri + term_list['database'] + '-versions/' + term_list['database'] + '-versions.csv'
+    versions_df = pd.read_csv(versions_url, na_filter=False)
+    
+    # retrieve current term metadata for term list
+    data_url = githubBaseUri + term_list['database'] + '/' + term_list['database'] + '.csv'
+    frame = pd.read_csv(data_url, na_filter=False)
+    for index,row in frame.iterrows():
+        row_list = [term_list['pref_ns_prefix'], term_list['pref_ns_uri'], row['term_localName'], row['label'], row['definition'], row['usage'], row['notes'], row['term_modified'], row['term_deprecated'], row['type']]
+        if vocab_type == 2:
+            row_list += [row['controlled_value_string']]
+        elif vocab_type == 3:
+            if row['skos_broader'] =='':
+                row_list += [row['controlled_value_string'], '']
+            else:
+                row_list += [row['controlled_value_string'], term_list['pref_ns_prefix'] + ':' + row['skos_broader']]
+        if organized_in_categories:
+            row_list.append(row['tdwgutility_organizedInClass'])
+
+        # Borrowed terms really don't have implemented versions. They may be lacking values for version_status.
+        # In their case, their version IRI will be omitted.
+        found = False
+        for vindex, vrow in versions_df.iterrows():
+            if vrow['term_localName']==row['term_localName'] and vrow['version_status']=='recommended':
+                found = True
+                version_iri = vrow['version']
+                # NOTE: the current hack for non-TDWG terms without a version is to append # to the end of the term IRI
+                if version_iri[len(version_iri)-1] == '#':
+                    version_iri = ''
+        if not found:
+            version_iri = ''
+        row_list.append(version_iri)
+
+        table_list.append(row_list)
+
+# Turn list of lists into dataframe
+terms_df = pd.DataFrame(table_list, columns = column_list)
+
+terms_sorted_by_label = terms_df.sort_values(by='label')
+terms_sorted_by_localname = terms_df.sort_values(by='term_localName')
+terms_sorted_by_label
+
+# generate the index of terms grouped by category and sorted alphabetically by lowercase term local name
+
+text = '### 3.1 Index By Term Name\n\n'
+text += '(See also [3.2 Index By Label](#32-index-by-label))\n\n'
+for category in range(0,len(display_order)):
+    text += '**' + display_label[category] + '**\n'
+    text += '\n'
+    if organized_in_categories:
+        filtered_table = terms_sorted_by_localname[terms_sorted_by_localname['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_localname
+        filtered_table.reset_index(drop=True, inplace=True)
+        
+    for row_index,row in filtered_table.iterrows():
+        curie = row['pref_ns_prefix'] + ":" + row['term_localName']
+        curie_anchor = curie.replace(':','_')
+        text += '[' + curie + '](#' + curie_anchor + ')'
+        if row_index < len(filtered_table) - 1:
+            text += ' |'
+        text += '\n'
+    text += '\n'
+index_by_name = text
+
+text = '\n\n'
+
+# Comment out the following two lines if there is no index by local names
+#text = '### 3.2 Index By Label\n\n'
+#text += '(See also [3.1 Index By Term Name](#31-index-by-term-name))\n\n'
+for category in range(0,len(display_order)):
+    if organized_in_categories:
+        text += '**' + display_label[category] + '**\n'
+        text += '\n'
+        filtered_table = terms_sorted_by_label[terms_sorted_by_label['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_label
+        filtered_table.reset_index(drop=True, inplace=True)
+        
+    for row_index,row in filtered_table.iterrows():
+        if row_index == 0 or (row_index != 0 and row['label'] != filtered_table.iloc[row_index - 1].loc['label']): # this is a hack to prevent duplicate labels
+            curie_anchor = row['pref_ns_prefix'] + "_" + row['term_localName']
+            text += '[' + row['label'] + '](#' + curie_anchor + ')'
+            if row_index < len(filtered_table) - 2 or (row_index == len(filtered_table) - 2 and row['label'] != filtered_table.iloc[row_index + 1].loc['label']):
+                text += ' |'
+            text += '\n'
+    text += '\n'
+index_by_label = text
+
+decisions_df = pd.read_csv('https://raw.githubusercontent.com/tdwg/rs.tdwg.org/master/decisions/decisions-links.csv', na_filter=False)
+
+# generate a table for each term, with terms grouped by category
+
+# generate the Markdown for the terms table
+text = '## 4 Vocabulary\n'
+for category in range(0,len(display_order)):
+    if organized_in_categories:
+        text += '### 4.' + str(category + 1) + ' ' + display_label[category] + '\n'
+        text += '\n'
+        text += display_comments[category] # insert the comments for the category, if any.
+        filtered_table = terms_sorted_by_localname[terms_sorted_by_localname['tdwgutility_organizedInClass']==display_order[category]]
+        filtered_table.reset_index(drop=True, inplace=True)
+    else:
+        filtered_table = terms_sorted_by_localname
+        filtered_table.reset_index(drop=True, inplace=True)
+
+    for row_index,row in filtered_table.iterrows():
+        text += '<table>\n'
+        curie = row['pref_ns_prefix'] + ":" + row['term_localName']
+        curieAnchor = curie.replace(':','_')
+        text += '\t<thead>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<th colspan="2"><a id="' + curieAnchor + '"></a>Term Name  ' + curie + '</th>\n'
+        text += '\t\t</tr>\n'
+        text += '\t</thead>\n'
+        text += '\t<tbody>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Term IRI</td>\n'
+        uri = row['pref_ns_uri'] + row['term_localName']
+        text += '\t\t\t<td><a href="' + uri + '">' + uri + '</a></td>\n'
+        text += '\t\t</tr>\n'
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Modified</td>\n'
+        text += '\t\t\t<td>' + row['term_modified'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['version_iri'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Term version IRI</td>\n'
+            text += '\t\t\t<td><a href="' + row['version_iri'] + '">' + row['version_iri'] + '</a></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Label</td>\n'
+        text += '\t\t\t<td>' + row['label'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['term_deprecated'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td></td>\n'
+            text += '\t\t\t<td><strong>This term is deprecated and should no longer be used.</strong></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Definition</td>\n'
+        text += '\t\t\t<td>' + row['definition'] + '</td>\n'
+        text += '\t\t</tr>\n'
+
+        if row['usage'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Usage</td>\n'
+            text += '\t\t\t<td>' + convert_link(convert_code(row['usage'])) + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if row['notes'] != '':
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Notes</td>\n'
+            text += '\t\t\t<td>' + convert_link(convert_code(row['notes'])) + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if (vocab_type == 2 or vocab_type == 3) and row['controlled_value_string'] != '': # controlled vocabulary
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Controlled value</td>\n'
+            text += '\t\t\t<td>' + row['controlled_value_string'] + '</td>\n'
+            text += '\t\t</tr>\n'
+
+        if vocab_type == 3 and row['skos_broader'] != '': # controlled vocabulary with skos:broader relationships
+            text += '\t\t<tr>\n'
+            text += '\t\t\t<td>Has broader concept</td>\n'
+            curieAnchor = row['skos_broader'].replace(':','_')
+            text += '\t\t\t<td><a href="#' + curieAnchor + '">' + row['skos_broader'] + '</a></td>\n'
+            text += '\t\t</tr>\n'
+
+        text += '\t\t<tr>\n'
+        text += '\t\t\t<td>Type</td>\n'
+        if row['type'] == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#Property':
+            text += '\t\t\t<td>Property</td>\n'
+        elif row['type'] == 'http://www.w3.org/2000/01/rdf-schema#Class':
+            text += '\t\t\t<td>Class</td>\n'
+        elif row['type'] == 'http://www.w3.org/2004/02/skos/core#Concept':
+            text += '\t\t\t<td>Concept</td>\n'
+        else:
+            text += '\t\t\t<td>' + row['type'] + '</td>\n' # this should rarely happen
+        text += '\t\t</tr>\n'
+
+        # Look up decisions related to this term
+        for drow_index,drow in decisions_df.iterrows():
+            if drow['linked_affected_resource'] == uri:
+                text += '\t\t<tr>\n'
+                text += '\t\t\t<td>Executive Committee decision</td>\n'
+                text += '\t\t\t<td><a href="http://rs.tdwg.org/decisions/' + drow['decision_localName'] + '">http://rs.tdwg.org/decisions/' + drow['decision_localName'] + '</a></td>\n'
+                text += '\t\t</tr>\n'                        
+
+        text += '\t</tbody>\n'
+        text += '</table>\n'
+        text += '\n'
+    text += '\n'
+term_table = text
+
+text = index_by_label + term_table
+
+# read in header and footer, merge with terms table, and output
+
+headerObject = open(headerFileName, 'rt', encoding='utf-8')
+header = headerObject.read()
+headerObject.close()
+
+footerObject = open(footerFileName, 'rt', encoding='utf-8')
+footer = footerObject.read()
+footerObject.close()
+
+output = header + text + footer
+outputObject = open(outFileName, 'wt', encoding='utf-8')
+outputObject.write(output)
+outputObject.close()
+    
+print('done')
+

--- a/build/pw-cv-build/termlist-header.md
+++ b/build/pw-cv-build/termlist-header.md
@@ -10,7 +10,7 @@ Preferred namespace abbreviation
 : dwcpw:
 
 Date version issued
-: 2020-10-13
+: 2021-09-01
 
 Date created
 : 2020-10-13
@@ -19,10 +19,13 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This document version
-: <http://rs.tdwg.org/dwc/doc/pw/2020-10-13>
+: <http://rs.tdwg.org/dwc/doc/pw/2021-09-01>
 
 Latest version of document
 : <http://rs.tdwg.org/dwc/doc/pw/>
+
+Previous version
+: <http://rs.tdwg.org/dwc/doc/pw/2020-10-13>
 
 Abstract
 : The Darwin Core term `pathway` provides information about the process by which an Organism came to be in a given place at a given time. The Pathway Controlled Vocabulary provides terms that should be used as values for `dwc:pathway` and `dwciri:pathway`. 
@@ -34,7 +37,7 @@ Creator
 : TDWG Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2020. Pathway Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/pw//2020-10-13>
+: Darwin Core Maintenance Group. 2021. Pathway Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/pw/2021-09-01>
 
 
 ## 1 Introduction

--- a/docs/doe/2020-10-13.md
+++ b/docs/doe/2020-10-13.md
@@ -10,7 +10,7 @@ Preferred namespace abbreviation
 : dwcdoe:
 
 Date version issued
-: 2021-09-01
+: 2020-10-13
 
 Date created
 : 2020-10-13
@@ -19,13 +19,13 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This document version
-: <http://rs.tdwg.org/dwc/doc/doe/2021-09-01>
+: <http://rs.tdwg.org/dwc/doc/doe/2020-10-13>
 
 Latest version of document
 : <http://rs.tdwg.org/dwc/doc/doe/>
 
-Previous version
-: <http://rs.tdwg.org/dwc/doc/doe/2020-10-13>
+Replaced by
+: <http://rs.tdwg.org/dwc/doc/doe/2021-09-01>
 
 Abstract
 : The Darwin Core term `degreeOfEstablishment` provides information about degree to which an Organism survives, reproduces, and expands its range at the given place and time.. The Degree of Establishment Controlled Vocabulary provides terms that should be used as values for `dwc:degreeOfEstablishment` and `dwciri:degreeOfEstablishment`. 
@@ -37,7 +37,7 @@ Creator
 : TDWG Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2021. Degree of Establishment Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/doe/2021-09-01>
+: Darwin Core Maintenance Group. 2020. Degree of Establishment Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/doe/2020-10-13>
 
 
 ## 1 Introduction
@@ -123,11 +123,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d001-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d001-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d001-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d001-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -135,11 +135,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Not transported beyond limits of native range.</td>
+			<td>Not transported beyond limits of native range</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Considered native and naturally occurring. See also "category A" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>Considered native and naturally occuring. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category A</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -169,11 +169,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d002-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d002-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d002-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d002-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -181,15 +181,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals in captivity or quarantine (i.e., individuals provided with conditions suitable for them, but explicit measures of containment are in place).</td>
+			<td>Individuals in captivity or quarantine (i.e. individuals provided with conditions suitable for them, but explicit measures of containment are in place)</td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>Only for cases where specific actions have been taken place to prevent escape of individuals or propagules.</td>
+			<td>Only for cases where specific actions have been taken place to prevent escape of individuals or propagules</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also "category B1" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category B1</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -219,11 +219,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d003-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d003-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d003-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d003-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -231,11 +231,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals in cultivation (i.e., individuals provided with conditions suitable for them, but explicit measures to prevent dispersal are limited at best).</td>
+			<td>Individuals in cultivation (i.e. individuals provided with conditions suitable for them, but explicit measures to prevent dispersal are limited at best)</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include gardens, parks and farms. See also "category B2" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>Examples include gardens, parks and farms. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category B2</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -265,11 +265,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d004-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d004-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d004-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d004-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -277,11 +277,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals directly released into novel environment.</td>
+			<td>Individuals directly released into novel environment</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>For example, fish stocked for angling, birds for hunting. See also "category B3" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>For example, fish stocked for angling, birds for hunting. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category B3</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -311,11 +311,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d005-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d005-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d005-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d005-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -323,11 +323,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals released outside of captivity or cultivation in a location, but incapable of surviving for a significant period.</td>
+			<td>Individuals released outside of captivity or cultivation in a location, but incapable of surviving for a significant period</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>For example, frost-tender plants sown or planted in a cold climate. See also "category C0" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>Such as frost tender plants sown or planted in a cold climate. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C0</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -357,11 +357,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d006-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d006-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d006-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d006-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -369,11 +369,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals surviving outside of captivity or cultivation in a location with no reproduction.</td>
+			<td>Individuals surviving outside of captivity or cultivation in a location, no reproduction</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Trees planted in the wild for forestry or ornament may come under this category. See also "category C1" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>Trees planted in the wild for forestry or ornament may come under this category. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C1</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -403,11 +403,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d007-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d007-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d007-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d007-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -415,11 +415,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals surviving outside of captivity or cultivation in a location. Reproduction is occurring, but population not self-sustaining.</td>
+			<td>Individuals surviving outside of captivity or cultivation in a location, reproduction is occurring, but population not self-sustaining</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Offspring are produced, but these either do not survive or are not fertile enough to maintain the population. See also "category C2" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>Offspring are produced, but these either do not survive or are fertile enough to maintain the population. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C2</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -449,11 +449,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d008-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d008-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d008-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d008-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -461,11 +461,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals surviving outside of captivity or cultivation in a location. Reproduction occurring, and population self-sustaining.</td>
+			<td>Individuals surviving outside of captivity or cultivation in a location, reproduction occurring, and population self-sustaining</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The population is maintained by reproduction, but is not spreading. See also "category C3" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>The population is maintained by reproduction, but is not spreading. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C3</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -495,11 +495,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d009-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d009-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d009-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d009-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -507,11 +507,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving a significant distance from the original point of introduction.</td>
+			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving a significant distance from the original point of introduction</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The population is maintained by reproduction and is spreading. See also "category D1" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>The population is maintained by reproduction and is spreading. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category D1</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -541,11 +541,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d010-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d010-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d010-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d010-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -553,11 +553,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving and reproducing a significant distance from the original point of introduction.</td>
+			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving and reproducing a significant distance from the original point of introduction</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The population is maintained by reproduction, is spreading, and its progeny are also reproducing and spreading. See also "category D2" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>The population is maintained by reproduction, is spreading, and their progeny is also reproducing and spreading. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category D2</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -587,11 +587,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d011-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d011-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d011-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d011-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -599,15 +599,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Fully invasive species, with individuals dispersing, surviving and reproducing at multiple sites across a spectrum of habitats and geographic range.</td>
+			<td>Fully invasive species, with individuals dispersing, surviving and reproducing at multiple sites across a greater or lesser spectrum of habitats and extent of occurrence</td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term is only used for those invasives with the highest degree of encroachment.</td>
+			<td>This term is only used for those invasives with the highest degree of encroachment</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also "category E" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
+			<td>See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category E</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>

--- a/docs/doe/index.md
+++ b/docs/doe/index.md
@@ -120,11 +120,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d001-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d001-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d001-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d001-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -132,11 +132,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Not transported beyond limits of native range</td>
+			<td>Not transported beyond limits of native range.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Considered native and naturally occuring. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category A</td>
+			<td>Considered native and naturally occurring. See also "category A" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -166,11 +166,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d002-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d002-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d002-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d002-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -178,15 +178,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals in captivity or quarantine (i.e. individuals provided with conditions suitable for them, but explicit measures of containment are in place)</td>
+			<td>Individuals in captivity or quarantine (i.e., individuals provided with conditions suitable for them, but explicit measures of containment are in place).</td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>Only for cases where specific actions have been taken place to prevent escape of individuals or propagules</td>
+			<td>Only for cases where specific actions have been taken place to prevent escape of individuals or propagules.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category B1</td>
+			<td>See also "category B1" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -216,11 +216,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d003-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d003-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d003-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d003-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -228,11 +228,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals in cultivation (i.e. individuals provided with conditions suitable for them, but explicit measures to prevent dispersal are limited at best)</td>
+			<td>Individuals in cultivation (i.e., individuals provided with conditions suitable for them, but explicit measures to prevent dispersal are limited at best).</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include gardens, parks and farms. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category B2</td>
+			<td>Examples include gardens, parks and farms. See also "category B2" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -262,11 +262,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d004-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d004-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d004-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d004-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -274,11 +274,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals directly released into novel environment</td>
+			<td>Individuals directly released into novel environment.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>For example, fish stocked for angling, birds for hunting. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category B3</td>
+			<td>For example, fish stocked for angling, birds for hunting. See also "category B3" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -308,11 +308,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d005-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d005-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d005-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d005-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -320,11 +320,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals released outside of captivity or cultivation in a location, but incapable of surviving for a significant period</td>
+			<td>Individuals released outside of captivity or cultivation in a location, but incapable of surviving for a significant period.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Such as frost tender plants sown or planted in a cold climate. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C0</td>
+			<td>For example, frost-tender plants sown or planted in a cold climate. See also "category C0" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -354,11 +354,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d006-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d006-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d006-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d006-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -366,11 +366,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals surviving outside of captivity or cultivation in a location, no reproduction</td>
+			<td>Individuals surviving outside of captivity or cultivation in a location with no reproduction.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Trees planted in the wild for forestry or ornament may come under this category. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C1</td>
+			<td>Trees planted in the wild for forestry or ornament may come under this category. See also "category C1" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -400,11 +400,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d007-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d007-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d007-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d007-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -412,11 +412,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals surviving outside of captivity or cultivation in a location, reproduction is occurring, but population not self-sustaining</td>
+			<td>Individuals surviving outside of captivity or cultivation in a location. Reproduction is occurring, but population not self-sustaining.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Offspring are produced, but these either do not survive or are fertile enough to maintain the population. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C2</td>
+			<td>Offspring are produced, but these either do not survive or are not fertile enough to maintain the population. See also "category C2" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -446,11 +446,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d008-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d008-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d008-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d008-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -458,11 +458,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Individuals surviving outside of captivity or cultivation in a location, reproduction occurring, and population self-sustaining</td>
+			<td>Individuals surviving outside of captivity or cultivation in a location. Reproduction occurring, and population self-sustaining.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The population is maintained by reproduction, but is not spreading. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category C3</td>
+			<td>The population is maintained by reproduction, but is not spreading. See also "category C3" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -492,11 +492,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d009-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d009-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d009-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d009-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -504,11 +504,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving a significant distance from the original point of introduction</td>
+			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving a significant distance from the original point of introduction.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The population is maintained by reproduction and is spreading. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category D1</td>
+			<td>The population is maintained by reproduction and is spreading. See also "category D1" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -538,11 +538,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d010-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d010-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d010-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d010-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -550,11 +550,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving and reproducing a significant distance from the original point of introduction</td>
+			<td>Self-sustaining population outside of captivity or cultivation, with individuals surviving and reproducing a significant distance from the original point of introduction.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The population is maintained by reproduction, is spreading, and their progeny is also reproducing and spreading. See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category D2</td>
+			<td>The population is maintained by reproduction, is spreading, and its progeny are also reproducing and spreading. See also "category D2" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -584,11 +584,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d011-2020-10-13">http://rs.tdwg.org/dwcdoe/values/version/d011-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcdoe/values/version/d011-2021-09-01">http://rs.tdwg.org/dwcdoe/values/version/d011-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -596,15 +596,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](http://r
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Fully invasive species, with individuals dispersing, surviving and reproducing at multiple sites across a greater or lesser spectrum of habitats and extent of occurrence</td>
+			<td>Fully invasive species, with individuals dispersing, surviving and reproducing at multiple sites across a spectrum of habitats and geographic range.</td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term is only used for those invasives with the highest degree of encroachment</td>
+			<td>This term is only used for those invasives with the highest degree of encroachment.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Blackburn et al. 2011 <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a> category E</td>
+			<td>See also "category E" in Blackburn et al. 2011. <a href="https://doi.org/10.1016/j.tree.2011.03.023">https://doi.org/10.1016/j.tree.2011.03.023</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>

--- a/docs/em/2020-10-13.md
+++ b/docs/em/2020-10-13.md
@@ -10,7 +10,7 @@ Preferred namespace abbreviation
 : dwcem:
 
 Date version issued
-: 2021-09-01
+: 2020-10-13
 
 Date created
 : 2020-10-13
@@ -19,13 +19,13 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This document version
-: <http://rs.tdwg.org/dwc/doc/em/2021-09-01>
+: <http://rs.tdwg.org/dwc/doc/em/2020-10-13>
 
 Latest version of document
 : <http://rs.tdwg.org/dwc/doc/em/>
 
-Previous version
-: <http://rs.tdwg.org/dwc/doc/em/2020-10-13>
+Replaced by
+: <http://rs.tdwg.org/dwc/doc/pw/2021-09-01>
 
 Abstract
 : The Darwin Core term `establishmentMeans` provides information about whether an organism or organisms have been introduced to a given place and time through the direct or indirect activity of modern humans. The Establishment Means Controlled Vocabulary provides terms that should be used as values for `dwc:establishmentMeans` and `dwciri:establishmentMeans`. 
@@ -37,7 +37,7 @@ Creator
 : TDWG Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2021. Establishment Means Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/em/2021-09-01>
+: Darwin Core Maintenance Group. 2020. Establishment Means Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/em/2020-10-13>
 
 
 ## 1 Introduction
@@ -118,11 +118,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e001-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e001-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e001-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e001-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -130,11 +130,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>A taxon occurring within its natural range.</td>
+			<td>A taxon occurring within its natural range</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>What is considered native to an area varies with the biogeographic history of an area and the local interpretation of what is a "natural range".</td>
+			<td>What is considered native to an area varies with the biogeographic history of an area and the local interpretation of what is a "natural range".  </td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -164,11 +164,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e002-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e002-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e002-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e002-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -176,11 +176,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>A taxon re-established by direct introduction by humans into an area that was once part of its natural range, but from where it had become extinct.</td>
+			<td>A taxon re-established by direct introduction by humans into an area which was once part of its natural range, but from where it had become extinct.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Where a taxon has become extirpated from an area where it had naturally occurred it may be returned to that area deliberately with the intension of re-establishing it.</td>
+			<td>Where a taxon has become extirpated from an area where it had naturally occurred it may be returned to that area deliberately with the intension of re-establishing it. </td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -210,11 +210,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e003-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e003-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e003-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e003-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -222,11 +222,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Establishment of a taxon by human agency into an area that is not part of its natural range.</td>
+			<td>Establishment of a taxon by human agency into an area that is not part of its natural range</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Organisms can be introduced to novel areas and habitats by human activity, either on purpose or by accident. Humans can also inadvertently create corridors that break down natural barriers to dispersal and allow organisms to spread beyond their natural range.</td>
+			<td>Organisms can be introduced to novel areas and habitats by human activity, either on purpose or by accident. Humans can also inadvertently create corridors that breakdown natural barriers to dispersal and allow organisms to spread beyond their natural range.</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -256,11 +256,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e004-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e004-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e004-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e004-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -268,11 +268,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Establishment of a taxon specifically with the intention of creating a self-sustaining wild population in an area that is not part of the taxon's natural range.</td>
+			<td>Establishment of a taxon specifically with the intention of creating a self-sustaining wild population in an area that is not part of the taxon's natural range</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>In the event of environmental change and habitat destruction a conservation option is to introduce a taxon into an area it did not naturally occur.</td>
+			<td>In the event of environmental change and habitat destruction a conservation option is to introduce a taxon into an area it did not naturally occur</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -348,11 +348,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e006-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e006-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e006-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e006-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -360,7 +360,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>The origin of the occurrence of the taxon in an area is obscure.</td>
+			<td>The origin of the occurrence of the taxon in an area is obscure</td>
 		</tr>
 		<tr>
 			<td>Notes</td>

--- a/docs/em/index.md
+++ b/docs/em/index.md
@@ -115,11 +115,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e001-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e001-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e001-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e001-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -127,11 +127,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>A taxon occurring within its natural range</td>
+			<td>A taxon occurring within its natural range.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>What is considered native to an area varies with the biogeographic history of an area and the local interpretation of what is a "natural range".  </td>
+			<td>What is considered native to an area varies with the biogeographic history of an area and the local interpretation of what is a "natural range".</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -161,11 +161,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e002-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e002-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e002-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e002-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -173,11 +173,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>A taxon re-established by direct introduction by humans into an area which was once part of its natural range, but from where it had become extinct.</td>
+			<td>A taxon re-established by direct introduction by humans into an area that was once part of its natural range, but from where it had become extinct.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Where a taxon has become extirpated from an area where it had naturally occurred it may be returned to that area deliberately with the intension of re-establishing it. </td>
+			<td>Where a taxon has become extirpated from an area where it had naturally occurred it may be returned to that area deliberately with the intension of re-establishing it.</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -207,11 +207,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e003-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e003-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e003-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e003-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -219,11 +219,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Establishment of a taxon by human agency into an area that is not part of its natural range</td>
+			<td>Establishment of a taxon by human agency into an area that is not part of its natural range.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Organisms can be introduced to novel areas and habitats by human activity, either on purpose or by accident. Humans can also inadvertently create corridors that breakdown natural barriers to dispersal and allow organisms to spread beyond their natural range.</td>
+			<td>Organisms can be introduced to novel areas and habitats by human activity, either on purpose or by accident. Humans can also inadvertently create corridors that break down natural barriers to dispersal and allow organisms to spread beyond their natural range.</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -253,11 +253,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e004-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e004-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e004-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e004-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -265,11 +265,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Establishment of a taxon specifically with the intention of creating a self-sustaining wild population in an area that is not part of the taxon's natural range</td>
+			<td>Establishment of a taxon specifically with the intention of creating a self-sustaining wild population in an area that is not part of the taxon's natural range.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>In the event of environmental change and habitat destruction a conservation option is to introduce a taxon into an area it did not naturally occur</td>
+			<td>In the event of environmental change and habitat destruction a conservation option is to introduce a taxon into an area it did not naturally occur.</td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -345,11 +345,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2020-10-13</td>
+			<td>2021-09-01</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcem/values/version/e006-2020-10-13">http://rs.tdwg.org/dwcem/values/version/e006-2020-10-13</a></td>
+			<td><a href="http://rs.tdwg.org/dwcem/values/version/e006-2021-09-01">http://rs.tdwg.org/dwcem/values/version/e006-2021-09-01</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -357,7 +357,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>The origin of the occurrence of the taxon in an area is obscure</td>
+			<td>The origin of the occurrence of the taxon in an area is obscure.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>

--- a/docs/pw/2020-10-13.md
+++ b/docs/pw/2020-10-13.md
@@ -10,7 +10,7 @@ Preferred namespace abbreviation
 : dwcpw:
 
 Date version issued
-: 2021-09-01
+: 2020-10-13
 
 Date created
 : 2020-10-13
@@ -19,13 +19,13 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This document version
-: <http://rs.tdwg.org/dwc/doc/pw/2021-09-01>
+: <http://rs.tdwg.org/dwc/doc/pw/2020-10-13>
 
 Latest version of document
 : <http://rs.tdwg.org/dwc/doc/pw/>
 
-Previous version
-: <http://rs.tdwg.org/dwc/doc/pw/2020-10-13>
+Replaced by
+: <http://rs.tdwg.org/dwc/doc/pw/2021-09-01>
 
 Abstract
 : The Darwin Core term `pathway` provides information about the process by which an Organism came to be in a given place at a given time. The Pathway Controlled Vocabulary provides terms that should be used as values for `dwc:pathway` and `dwciri:pathway`. 
@@ -37,7 +37,7 @@ Creator
 : TDWG Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2021. Pathway Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/pw/2021-09-01>
+: Darwin Core Maintenance Group. 2020. Pathway Controlled Vocabulary List of Terms. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/pw/2020-10-13>
 
 
 ## 1 Introduction
@@ -165,11 +165,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p001-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p001-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p001-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p001-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -181,7 +181,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Released intentionally into the (semi)natural environment with the purpose of controlling the population(s) of one or more organisms. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Released intentionally into the (semi)natural environment with the purpose of controlling the population(s) of one or more organisms. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -215,11 +215,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p002-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p002-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p002-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p002-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -227,11 +227,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Organisms introduced for the purpose of erosion control/dune stabilization (windbreaks, hedges, etc.).</td>
+			<td>Organisms introduced for the purpose of erosion control/dune stabilization (windbreaks, hedges, etc).</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Probably only applicable to plants. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Probably only applicable only to plants. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -265,11 +265,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p003-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p003-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p003-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p003-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -281,7 +281,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Largely applicable to freshwater and anadromous fish. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Largely applicable to freshwater and anadromous fish. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -315,11 +315,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p004-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p004-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p004-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p004-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -331,7 +331,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Largely applicable to terrestrial vertebrates. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Largely applicable to terrestrial vertebrates. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -365,11 +365,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p005-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p005-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p005-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p005-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -381,7 +381,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>"Improvement" in this context is intended for introductions for the purpose of aesthetic enhancement of the landscape, as opposed to practical introductions for the purpose of erosion control, agriculture, forestry etc. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>"Improvement" in this context is intended for introductions for the purpose of aesthetic enhancement of the landscape, as opposed to practical introductions for the purpose of erosion control, agriculture, forestry etc. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -415,11 +415,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p006-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p006-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p006-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p006-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -431,7 +431,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The organism was released with the intention of improving the conservation status of the species or the conservation status other species in the habitat. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>The organism was released with the intention of improving its conservation status of the species or the conservation status other species in the habitat. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -465,11 +465,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p007-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p007-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p007-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p007-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -481,7 +481,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>This term refers to organisms intentionally and directly released into the wild to serve a specific purpose. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>This term refers to organisms intentionally and directly released into the wild to serve a specific purpose. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -515,11 +515,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p008-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p008-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p008-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p008-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -527,11 +527,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>A catch-all term for intentional releases not for human use that are not covered by other more specific terms.</td>
+			<td>A catch-all for intentional releases not for human use that are not covered by other more specific terms.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Compare with "other escape from confinement". See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Compare with "other escape from confinement". See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -565,11 +565,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p009-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p009-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p009-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p009-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -577,11 +577,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Plants grown with the intention of harvesting.</td>
+			<td>Plants grown with then intention of harvesting.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -615,11 +615,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p010-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p010-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p010-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p010-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -631,7 +631,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -665,11 +665,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-28</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p011-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p011-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p011-2020-10-28">http://rs.tdwg.org/dwcpw/values/version/p011-2020-10-28</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -681,7 +681,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -715,11 +715,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-28</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p012-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p012-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p012-2020-10-28">http://rs.tdwg.org/dwcpw/values/version/p012-2020-10-28</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -731,11 +731,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>Animals kept for hunting, such as falcons and ferrets, SHOULD be included here, not under the hunting term.</td>
+			<td>Animals kept for hunting, such as falcons and ferrets SHOULD be included here, not under the hunting term</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -769,11 +769,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p013-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p013-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p013-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p013-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -785,7 +785,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Farmed animals are generally kept in a defined area, such as a fields. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Farmed animals are generally kept in a defined area, such as a fields. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -819,11 +819,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p014-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p014-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p014-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p014-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -835,7 +835,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -869,11 +869,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p015-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p015-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p015-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p015-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -881,11 +881,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Organisms escaped from a fur farm, including unauthorised releases.</td>
+			<td>Organisms escaped from a fur farms, including unauthorised releases.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Probably only applicable to vertebrates raised for their pelts and skins. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Probably only applicable to vertebrates raised for their pelts and skins. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -919,11 +919,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p016-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p016-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p016-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p016-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -931,15 +931,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Plants distributed by the ornamental and decorative plants industry.</td>
+			<td>Plants distributed by the ornamental and decorative plants industry. </td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term excludes plants and other organisms from aquaria and terrariums, which SHOULD be classified under the pet/aquarium/terrarium term.</td>
+			<td>This term excludes plants and other organisms from aquaria and terrariums from the aquarium and terrarium trade which SHOULD be classified under the pet/aquarium/terrarium term.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -973,11 +973,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p017-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p017-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p017-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p017-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -989,7 +989,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1023,11 +1023,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p018-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p018-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p018-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p018-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1035,11 +1035,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Plants and animals introduced for the purpose of breeding or scientific and medical research, including science education.</td>
+			<td>Plants and animals introduced for the purpose of breeding, scientific and medical research, including science education.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1073,11 +1073,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p019-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p019-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p019-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p019-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1085,11 +1085,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Live food imported for human consumption or live bait, such as shellfish and snails.</td>
+			<td>Live food imported for human consumption, such as shellfish and snails, and for live bait. </td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Live food, such as mealworms, for the organisms kept as pets should be classified under the pet term. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Live food, such as mealworms, for the organisms kept as pets should be classified under the pet term. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1123,11 +1123,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p020-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p020-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p020-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p020-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1139,7 +1139,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1173,11 +1173,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p021-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p021-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p021-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p021-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1189,7 +1189,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>These may be other plants, diseases, fungi and animals. They may be attached to the plant or within the soil. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>These may be other plants, diseases, fungi and animals. They may be attached to the plant or within the soil. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1223,11 +1223,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p022-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p022-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p022-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p022-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1239,7 +1239,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Typical examples include crustaceans, cephalopods and molluscs. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Typical examples include crustaceans, cephalopods and molluscs. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1273,11 +1273,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p023-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p023-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p023-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p023-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1285,11 +1285,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Foods for human consumption, whether they are transported live or dead.</td>
+			<td>Foods for human consumption, whether they are transported life or dead.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>This term includes unintentional introduction of contaminants such as diseases on those foods and in the case of plants, should include seeds. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>This term includes unintentional introduction of contaminants such as diseases on those foods and in the case of plants, should include seeds. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1323,11 +1323,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p024-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p024-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p024-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p024-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1339,11 +1339,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term excludes parasites and pathogens, which SHOULD be classified under their own specific term ("parasites on animals").</td>
+			<td>This term excludes parasites and pathogens, which SHOULD be classified under their own specific term ("parasites on animals"). </td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Transported animals carry other organisms in their coats, in their guts and in soil on their hooves and feet. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Transported animals carry other organisms in their coat, on thier gut and in soil on their hooves and feet. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1377,11 +1377,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p025-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p025-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p025-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p025-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1393,7 +1393,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1427,11 +1427,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p026-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p026-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p026-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p026-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1443,11 +1443,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term excludes organisms carried on contaminant nursery material, seed contaminants, and the material from the timber trade, which SHOULD be classified under their own pathway terms.</td>
+			<td>This term excludes organisms carried on contaminant nursery material, seed contaminants, and the timber trade, which SHOULD be classified under their own pathway terms.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1481,11 +1481,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p027-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p027-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p027-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p027-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1497,7 +1497,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1531,11 +1531,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p028-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p028-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p028-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p028-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1547,7 +1547,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>These may be parasites or pathogens of seeds or species that eat seeds, whether intended to be transported or not. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>These may be parasites or pathogens of the seeds, seeds of other species not intended to be transported, or species that eat seeds. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1581,11 +1581,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p029-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p029-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p029-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p029-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1593,15 +1593,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Contaminants on unprocessed timber, processed wood and wood-derived products.</td>
+			<td>Contaminants on unprocessed timber, processed wood and wood derived products.</td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term excludes packing material and habitat material made from wood, which SHOULD be included under their own terms ("packing material" and "transportation of habitat material").</td>
+			<td>This term excludes packing material and habitat material made from wood that SHOULD be included under their own terms ("packing material" and "transportation of habitat material").</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include wooden furniture, saw dust and fire wood. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Examples include wooden furniture, saw dust and fire wood. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1635,11 +1635,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p030-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p030-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p030-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p030-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1651,7 +1651,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include materials such as soil, vegetation, straw and wood chips. Unless these materials are sterilised the organisms can be transported with their habitat to a new location. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Examples include materials such as soil, vegetation, straw and wood chips. Unless these materials are sterilised the organisms can be transported with their habitat to a new location. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1685,11 +1685,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p031-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p031-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p031-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p031-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1701,7 +1701,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1735,11 +1735,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p032-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p032-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p032-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p032-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1747,11 +1747,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Stowaways transported in or on cargo containers or bulk cargo units.</td>
+			<td>Stowaways transported in or on the cargo containers or bulk cargo units themselves.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The difference between this category and others, such as "hitchhikers on ship/boat", is that the organism embarked and disembarked from the container rather than the ship. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>The difference between this category and others, such as "hitchhikers on ship/boat", is that the organism embarked and disembarked from the container itself rather than the ship. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1785,11 +1785,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p033-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p033-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p033-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p033-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1801,7 +1801,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>This term does not apply to organisms that embarked in containers that were subsequently loaded onto an aircraft. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>This term does not apply to organisms that embarked onto containers that were subsequently loaded on to an aircraft. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1835,11 +1835,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p034-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p034-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p034-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p034-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1851,7 +1851,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>This term does not apply to organisms that embarked in containers that are subsequently loaded onto the ship, nor to contaminants of products loaded onto the ship. The term is intended for organisms that directly interact with the boat or ship. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>This term does not apply to organisms that embarked containers that are subsequently loaded on the ship, nor to contaminents of products loaded on the ship. The term is intended for organisms that directly interact with the boat or ship. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1885,11 +1885,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p035-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p035-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p035-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p035-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1901,7 +1901,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>This includes military equipment, farm machinery and manufacturing equipment. This term does not include products carried by vehicles. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>This includes military equipment, farm machinery and manufacturing equipment. This term does not include products carried by vehicles. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1935,11 +1935,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p036-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p036-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p036-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p036-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -1947,15 +1947,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Organisms transported on people and/or their personal luggage.</td>
+			<td>Organisms transported on people themselves and/or their personal luggage.</td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>This term excludes recreational angling equipment, which SHOULD be classified under its own term ("angling/fishing equipment").</td>
+			<td>This term excludes recreational angling equipment, which SHOULD be classified under its own term ("angling/fishing equipment"). </td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include organisms transported by tourists. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Examples include organisms transported by tourists. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -1989,11 +1989,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p037-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p037-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p037-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p037-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2005,7 +2005,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include woodern pallets, boxes, bags and baskets. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Examples include woodern pallets, boxes, bags and baskets. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2039,11 +2039,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p038-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p038-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p038-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p038-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2055,7 +2055,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2089,11 +2089,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p039-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p039-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p039-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p039-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2101,11 +2101,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Organisms that attach themselves to the subsurface hull of boats and ships.</td>
+			<td>Organisms that attach themselves to the subsurface hull of boats and ships. </td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2139,11 +2139,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p040-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p040-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p040-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p040-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2155,7 +2155,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>These organisms may be carried on or within the vehicle. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>These organisms may be carried on or within the vehicle. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2189,11 +2189,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p041-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p041-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p041-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p041-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2201,11 +2201,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>A catch-all term for any transport related dispersal that is not covered in other terms.</td>
+			<td>A catchall term for any transport related dispersal that is not covered in other terms.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>Examples include fouling from offshore oil and gas platforms, offshore renewable energy sites (such as wind farms, pipelines, cable transport, etc. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>Examples include the movement of offshore installations, such as drilling platforms, but also pipeline and cable transport. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2239,11 +2239,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p042-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p042-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p042-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p042-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2251,15 +2251,15 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>Organisms that dispersed through artificial waterways created to connect previosuly unconnected water bodies.</td>
+			<td>Organisms that dispersed through artificial waterways created to connect previosuly unconnected water bodies. </td>
 		</tr>
 		<tr>
 			<td>Usage</td>
-			<td>Organisms transported along these corridors in ballast or as hull fouling SHOULD be categorised under the "ship/boat ballast water" or "ship/boat hull fouling" terms.</td>
+			<td>Organisms transported along these corridors in ballast, on as hull fouling SHOULD be categorised under the "ship/boat ballast water" or "ship/boat hull fouling" terms. </td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2293,11 +2293,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p043-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p043-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p043-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p043-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2309,7 +2309,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2343,11 +2343,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p044-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p044-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p044-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p044-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2359,7 +2359,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>These are alien species that have previously been introduced through one of these pathways: release in nature, excape from confinement, transport-contaminant, transport-stowaway, or corridor. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>These are alien species that have previously been introduced through one of these pathways: release in nature, excape from confinement, transport-contaminant, transport-stowaway, or corridor. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2393,11 +2393,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-28</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p045-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p045-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p045-2020-10-28">http://rs.tdwg.org/dwcpw/values/version/p045-2020-10-28</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2409,7 +2409,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2443,11 +2443,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p046-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p046-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p046-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p046-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2459,7 +2459,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2493,11 +2493,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p047-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p047-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p047-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p047-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2509,7 +2509,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>An alien species is a contaminant if it had a trophic or biotic relationship to organisms or items being transported and was to some extent dependent on them for survival. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>An alien species is a contaminant if it had a trophic or biotic relationship to organisms or items being transported and was to some extent dependent on them for survival. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2543,11 +2543,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p048-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p048-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p048-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p048-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2555,11 +2555,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Definition</td>
-			<td>An umbrella term for all species transported by riding on forms of transport where the organism has a direct interaction with the transport and is not merely carried as part of, or a contaminant of cargo.</td>
+			<td>An umbrella term for all species transported by riding on forms of transport where the organism has a direct interation with the transport and is not merely carried as part of, or a contaminent of cargo.</td>
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>A stowaway has no trophic or biotic relationship to the organisms or items being transported. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>A stowaway has no trophic or biotic relationship to the organisms or items being transported. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2593,11 +2593,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p049-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p049-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p049-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p049-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2609,7 +2609,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2643,11 +2643,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p050-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p050-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p050-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p050-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2659,7 +2659,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>The term refers to secondary dispersal from an area where the taxon is also alien. See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>The term refers to secondary dispersal from an area where the taxon is also alien. See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2693,11 +2693,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p051-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p051-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p051-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p051-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2709,7 +2709,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2739,11 +2739,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p052-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p052-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p052-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p052-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2755,7 +2755,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>
@@ -2785,11 +2785,11 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Modified</td>
-			<td>2021-09-01</td>
+			<td>2020-10-13</td>
 		</tr>
 		<tr>
 			<td>Term version IRI</td>
-			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p053-2021-09-01">http://rs.tdwg.org/dwcpw/values/version/p053-2021-09-01</a></td>
+			<td><a href="http://rs.tdwg.org/dwcpw/values/version/p053-2020-10-13">http://rs.tdwg.org/dwcpw/values/version/p053-2020-10-13</a></td>
 		</tr>
 		<tr>
 			<td>Label</td>
@@ -2801,7 +2801,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Notes</td>
-			<td>See also Harrower et al. 2017. <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
+			<td>See also Harrower et al. 2017 <a href="http://nora.nerc.ac.uk/id/eprint/519129">http://nora.nerc.ac.uk/id/eprint/519129</a></td>
 		</tr>
 		<tr>
 			<td>Controlled value</td>


### PR DESCRIPTION
@tucotuco In this pull request, I've moved the build scripts from Jupyter notebooks to stand-alone Python scripts. I then ran the scripts but forgot to update the termlist headers, so updated them, created the old version copies, and re-ran the scripts. I think that everything is now as it should be, but please make sure that the diffs make sense.

I still need to update the document metadata in rs.tdwg.org so that the old versions of the lists of terms documents will dereference. I'll try to do that tomorrow. But otherwise, I think everything should work with respect to the term IRIs themselves dereferencing in a browser after this merge.