### PR TITLE
removed duplicate version-attribute that caused invalid schema file

### DIFF
--- a/docs/xml/tdwg_basetypes.xsd
+++ b/docs/xml/tdwg_basetypes.xsd
@@ -15,7 +15,7 @@
 <xs:schema 
     version="2021-07-15"
 	xmlns:xs="http://www.w3.org/2001/XMLSchema"
-	elementFormDefault="unqualified" version="0.5">
+	elementFormDefault="unqualified">
 
 	<!-- ============================================================== -->
 	<!-- Types                                                          -->


### PR DESCRIPTION
I wanted to run some validation of a file that included the TDWG Basetypes Schema from this repository and it failed because the file is not well formed, because it contained a duplicate attribute version in the xs:schema element (document root element): 

`<xs:schema version="2021-07-15" [...] version="0.5">`

Since the `version="2021-07-15"` was added in the last commit, the old `version="0.5"` is outdated and needs to be removed. The only question is whether the version now needs to be bumped to today's date. So feel free to edit this commit to adjust it accordingly.