### PR TITLE
Examples and template for #32 and #444

### DIFF
--- a/docs/examples/template.md
+++ b/docs/examples/template.md
@@ -1,0 +1,33 @@
+---
+# As a template for authors, this page is not included in the published site.
+# This section should be removed when copying the template.
+published: false
+---
+# _TermName_ Examples
+
+Title
+: termName Examples
+
+Date modified
+: 20XX-XX-XX
+
+Part of TDWG Standard
+: Not formally part of any standard.
+
+Abstract
+: This document provides examples and guidance for the use of Darwin Core termName.
+
+Contributors
+: _Your name(s)_
+
+Creator
+: Darwin Core Maintenance Group
+
+Bibliographic citation
+: Darwin Core Maintenance Group. 2023. termName examples. Biodiversity Information Standards (TDWG). <https://dwc.tdwg.org/examples/termName/>
+
+The following provides examples and guidance for the use of Darwin Core termName.
+
+_Provide guidance and examples as suitable here.
+Examples are non-normative, and therefore can be changed outside the ratification process but should be reviewed by a member of the DwC maintenance group.
+This review typically happens during the github pull request process._

--- a/docs/examples/verbatimLabel.md
+++ b/docs/examples/verbatimLabel.md
@@ -1,0 +1,74 @@
+# verbatimLabel Examples
+
+Title
+: verbatimLabel Examples
+
+Date modified
+: 2023-06-14
+
+Part of TDWG Standard
+: Not formally part of any standard. 
+
+Abstract
+: This document provides examples and guidance for the use of Darwin Core verbatimLabel.
+
+Contributors
+: Tommy McElrath, Debbie Paul, Christian Bölling, Tim Robertson
+
+Creator
+: Darwin Core Maintenance Group
+
+Bibliographic citation
+: Darwin Core Maintenance Group. 2023. verbatimLabel examples. Biodiversity Information Standards (TDWG). <https://dwc.tdwg.org/examples/verbatimLabel/>
+
+The following provides examples and guidance for the use of Darwin Core verbatimLabel.
+
+## Example 1
+
+For a label affixed to a pinned insect specimen, the verbatimLabel would contain:
+
+> ILL: Union Co.
+> Wolf Lake by Powder Plant
+> Bridge. 1 March 1975
+> Coll. S. Ketzler, S. Herbert
+> 
+> Monotoma
+> longicollis 4 ♂
+> Det TC McElrath 2018
+> 
+> INHS
+> Insect Collection
+> 456782
+
+With comment `verbatimLabel derived from human transcription` added in occurrenceRemarks.
+
+## Example 2
+
+When using Optical Character Recognition (OCR) techniques against an herbarium sheet, the verbatimLabel would contain:
+
+> 0 1 2 3 4 5 6 7 8 9 10
+> cm	copyright reserved
+> The New York
+> Botanical Garden
+> 
+> 
+> NEW YORK
+> BOTANICAL
+> GARDEN
+> 
+> 
+> NEW YORK BOTANICAL GARDEN
+> ACADEMY OF NATURAL SCIENCES OF PHILADELPHIA
+> EXPLORATION OF BERMUDA
+> NO. 355
+> Cymbalaria Cymbalaria (L.) Wettst
+> Roadside wall, The Crawl.
+> STEWARDSON BROWN
+> }COLLECTORS AUG. 31-SEPT. 20, 1905
+> N.L. BRITTON
+> 
+> 
+> NEW YORK BOTANICAL GARDEN
+> 00499439
+      
+With comment `verbatimLabel derived from unadulterated OCR output` added in occurrenceRemarks.


### PR DESCRIPTION
This provides a template for documenting examples and the examples for `verbatimLabel`.

This has been reviewed by @peterdesmet (thanks Peter) for formatting and discussion around the filenames etc. This will result in a page on https://dwc.tdwg.org/examples/verbatimLabel appearing as follows:

![image](https://github.com/tdwg/dwc/assets/237221/645aaf5e-aeab-4951-9f95-5b279a36ac0a)
