### PR TITLE
Make menus match document names

### DIFF
--- a/docs/_data/navigation.json
+++ b/docs/_data/navigation.json
@@ -14,11 +14,11 @@
         "text": "---"
       },
       {
-        "text": "Chronometric Age Extension",
+        "text": "Chronometric Age Vocabulary",
         "href": "https://chrono.tdwg.org/list/"
       },
       {
-        "text": "Humboldt Extension",
+        "text": "Humboldt Extension Vocabulary",
         "href": "https://eco.tdwg.org/list/"
       },
       {


### PR DESCRIPTION
There has been confusion in the use of "extension". In many minds, it means DwC-A extensions. So it is confusing when we use "extension" when we actually mean "vocabulary". I have modified the navigation menu, so that the Humboldt and Chrono items say "vocabulary" and more closely match the actual document names.

Matt, I am requesting your review since I am not sure what implications this will have on the translated menus. I see that there is a script for generating menus, but don't know if Crowdin will automatically get pinged with this change.

FWIW, John W. is also in favor of making this change.