### PR TITLE
rebuild pages using fresh data from rs.tdwg.org

### DIFF
--- a/docs/dp/index.md
+++ b/docs/dp/index.md
@@ -13,10 +13,10 @@ Part of TDWG Standard
 : <http://www.tdwg.org/standards/450>
 
 This version
-: <http://rs.tdwg.org/dwc/terms/guides/dp/2026-05-26>
+: <http://rs.tdwg.org/dwc/doc/dp/2026-05-26>
 
 Latest version
-: <http://rs.tdwg.org/dwc/terms/guides/dp/>
+: <http://rs.tdwg.org/dwc/doc/dp/>
 
 Abstract
 : Specification for creating a Darwin Core Data Package.
@@ -28,7 +28,7 @@ Creator
 : Darwin Core Maintenance Group
 
 Bibliographic citation
-: Darwin Core Maintenance Group. 2026. Darwin Core Data Package guide. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/terms/guides/dp/2026-05-26>
+: Darwin Core Maintenance Group. 2026. Darwin Core Data Package guide. Biodiversity Information Standards (TDWG). <http://rs.tdwg.org/dwc/doc/dp/2026-05-26>
 
 [dp.v1]: https://specs.frictionlessdata.io/
 [dp.v2]: https://datapackage.org/

--- a/docs/em/index.md
+++ b/docs/em/index.md
@@ -202,7 +202,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Executive Committee decision</td>
-			<td><a href="http://rs.tdwg.org/decisions/decision-2026-05-26_58">http://rs.tdwg.org/decisions/decision-2026-05-26_58</a></td>
+			<td><a href="http://rs.tdwg.org/decisions/decision-2026-05-26_61">http://rs.tdwg.org/decisions/decision-2026-05-26_61</a></td>
 		</tr>
 	</tbody>
 </table>
@@ -436,7 +436,7 @@ Due to the requirements of [Section 1.4.3 of the Darwin Core RDF Guide](https://
 		</tr>
 		<tr>
 			<td>Executive Committee decision</td>
-			<td><a href="http://rs.tdwg.org/decisions/decision-2026-05-26_58">http://rs.tdwg.org/decisions/decision-2026-05-26_58</a></td>
+			<td><a href="http://rs.tdwg.org/decisions/decision-2026-05-26_61">http://rs.tdwg.org/decisions/decision-2026-05-26_61</a></td>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
This fixes https://github.com/tdwg/dwc/issues/891 by running 

```
build_other_doc_header.py --slug dp --dir dwc_doc_dp
```

using the most recent rs.tdwg.org metadata. Also, re-running `build-webpages.py` discovered two executive decisions that had not been updated after the corrections were made to rs.tdwg.org